### PR TITLE
Fix stray text in project R code

### DIFF
--- a/fp/20236_FinalProject.qmd
+++ b/fp/20236_FinalProject.qmd
@@ -930,7 +930,7 @@ sims.level <- replicate(
   n.sims,
   {
     full.draw <- dlmBSample(modFilt)       # one draw
-    as.numeric(full.draw[-1, 1])           # drop init, take level              QUI IL TOSTAPANE INIZIA A SCALDARSI
+    as.numeric(full.draw[-1, 1])           # drop init, take level
   }
 )
 


### PR DESCRIPTION
## Summary
- remove an accidental sentence from the `fp/20236_FinalProject.qmd` R chunk

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408abfde38833186187518a9052991